### PR TITLE
Add return article html

### DIFF
--- a/articletext.go
+++ b/articletext.go
@@ -38,6 +38,14 @@ func processArticle(doc *goquery.Document) *goquery.Selection {
 	return getPrimarySelection(docselection)
 }
 
+func processArticleToHtml(doc *goquery.Document) (string, error) {
+	if doc == nil {
+		return "", nil
+	}
+
+	return processArticle(doc).Html()
+}
+
 // return parent node path and attributes
 func processArticleToSignature(doc *goquery.Document) (string, error) {
 	if doc == nil {

--- a/articletext.go
+++ b/articletext.go
@@ -27,28 +27,32 @@ func init() {
 
 // the function prepares a document for analysing
 // cleans a DOM object and starts analysing
-func processArticle(doc *goquery.Document, responsetype int) (string, error) {
-
-	if doc == nil {
-		return "", nil
-	}
-
+func processArticle(doc *goquery.Document) *goquery.Selection {
 	// get clone of a selection. Clone is neede,d because we willdo some transformations
-
 	docselection := doc.Selection.Clone()
 
 	// preprocess. Remove all tags that are not useful and can make parsing wrong
 	cleanDocument(docselection)
 
 	// get a selection that contains a text of a page (only primary or article text)
-	selection := getPrimarySelection(docselection)
+	return getPrimarySelection(docselection)
+}
 
-	if responsetype == 2 {
-		// return parent node path and attributes
-		return getSelectionSignature(selection), nil
+// return parent node path and attributes
+func processArticleToSignature(doc *goquery.Document) (string, error) {
+	if doc == nil {
+		return "", nil
 	}
 
-	return getTextFromHtml(selection), nil
+	return getSelectionSignature(processArticle(doc)), nil
+}
+
+func processArticleToText(doc *goquery.Document) (string, error) {
+	if doc == nil {
+		return "", nil
+	}
+
+	return getTextFromHtml(processArticle(doc)), nil
 }
 
 // clean HTML document. Removes all tags that are not useful

--- a/exported.go
+++ b/exported.go
@@ -39,7 +39,7 @@ func GetArticleTextFromUrl(url string) (string, error) {
 		return "", err
 	}
 
-	return processArticle(doc, 1)
+	return processArticleToText(doc)
 }
 
 // extracts useful text from a html document presented as a Reader object
@@ -52,7 +52,7 @@ func GetArticleText(input io.Reader) (string, error) {
 		return "", err
 	}
 
-	return processArticle(doc, 1)
+	return processArticleToText(doc)
 }
 
 // extracts useful text from a html file
@@ -78,7 +78,7 @@ func GetArticleSignatureFromUrl(url string) (string, error) {
 		return "", err
 	}
 
-	return processArticle(doc, 2)
+	return processArticleToSignature(doc)
 }
 
 // extracts useful text from a html document presented as a Reader object
@@ -91,7 +91,7 @@ func GetArticleSignature(input io.Reader) (string, error) {
 		return "", err
 	}
 
-	return processArticle(doc, 2)
+	return processArticleToSignature(doc)
 }
 
 // extracts useful text from a html file

--- a/exported.go
+++ b/exported.go
@@ -17,6 +17,28 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
+// extracts useful html part from a html document presented as a Reader object
+func GetArticleHtmlFromReader(input io.Reader) (string, error) {
+	doc, err := goquery.NewDocumentFromReader(input)
+	if err != nil {
+		log.Fatal(err)
+		return "", err
+	}
+
+	return processArticleToHtml(doc)
+}
+
+// extracts useful html part from a html page presented by an url
+func GetArticleHtmlFromUrl(url string) (string, error) {
+	doc, err := goquery.NewDocument(url)
+	if err != nil {
+		log.Fatal(err)
+		return "", err
+	}
+
+	return processArticleToHtml(doc)
+}
+
 // extracts useful text from a html file
 func GetArticleTextFromFile(filepath string) (string, error) {
 	// create reader from file


### PR DESCRIPTION
Hello Roman,

I did a refactor of `processArticle` method and added two methods `GetArticleHtmlFromReader` and `GetArticleHtmlFromUrl` to get HTML of the article. Let me know if I should change something.

In another hand, I had to implement standardization of charset to UTF-8 in my code. I could pass this functionality also to your library in another pull request but it requires 3rd party libraries. Let me know what do you think.

PS. Thank for creating this simple and useful library.

Regards,
Denys